### PR TITLE
Fix fallback model: allow None reset and custom model

### DIFF
--- a/lib/features/onboarding/presentation/onboarding_page.dart
+++ b/lib/features/onboarding/presentation/onboarding_page.dart
@@ -319,6 +319,8 @@ class _OnboardingPageState extends ConsumerState<OnboardingPage> {
         return AIConfigurationSection(
           apiKeyController: _formManager.apiKeyController,
           customModelController: _formManager.customModelController,
+          customFallbackModelController:
+              _formManager.customFallbackModelController,
           selectedModel: state.selectedModel,
           fallbackModel: state.fallbackModel,
           availableModels: controller.availableModels,

--- a/lib/features/settings/presentation/managers/settings_form_manager.dart
+++ b/lib/features/settings/presentation/managers/settings_form_manager.dart
@@ -16,6 +16,7 @@ class SettingsFormManager {
 
   final apiKeyController = TextEditingController();
   final customModelController = TextEditingController();
+  final customFallbackModelController = TextEditingController();
   final ageController = TextEditingController();
   final weightController = TextEditingController();
   final heightController = TextEditingController();
@@ -36,6 +37,7 @@ class SettingsFormManager {
   void dispose() {
     apiKeyController.dispose();
     customModelController.dispose();
+    customFallbackModelController.dispose();
     ageController.dispose();
     weightController.dispose();
     heightController.dispose();
@@ -50,6 +52,8 @@ class SettingsFormManager {
         .loadSettings(
           onKeyLoaded: (key) => apiKeyController.text = key,
           onCustomModelLoaded: (model) => customModelController.text = model,
+          onCustomFallbackLoaded: (model) =>
+              customFallbackModelController.text = model,
           onProfileLoaded: (UserProfile profile) {
             ageController.text = profile.age.toString();
             weightController.text = profile.weightKg.toString();
@@ -97,6 +101,7 @@ class SettingsFormManager {
         .save(
           apiKey: apiKeyController.text,
           customModel: customModelController.text,
+          customFallbackModel: customFallbackModelController.text,
           age: ageController.text,
           weight: weightController.text,
           height: heightController.text,
@@ -122,6 +127,8 @@ class SettingsFormManager {
       apiKeyController.text,
       state.selectedModel,
       customModelController.text,
+      state.fallbackModel,
+      customFallbackModelController.text,
       ageController.text,
       weightController.text,
       heightController.text,

--- a/lib/features/settings/presentation/settings_controller.dart
+++ b/lib/features/settings/presentation/settings_controller.dart
@@ -10,6 +10,10 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'settings_controller.g.dart';
 
+/// Sentinel used by [SettingsState.copyWith] to distinguish "argument omitted"
+/// from "explicitly set to null" for nullable fields like [fallbackModel].
+const Object _kUnset = Object();
+
 class SettingsState {
   SettingsState({
     this.isLoading = false,
@@ -34,7 +38,7 @@ class SettingsState {
     bool? isLoading,
     bool? isSyncing,
     String? selectedModel,
-    String? fallbackModel,
+    Object? fallbackModel = _kUnset,
     String? gender,
     String? activityLevel,
     List<NutritionMetricType>? homeMetricTypes,
@@ -43,7 +47,9 @@ class SettingsState {
       isLoading: isLoading ?? this.isLoading,
       isSyncing: isSyncing ?? this.isSyncing,
       selectedModel: selectedModel ?? this.selectedModel,
-      fallbackModel: fallbackModel ?? this.fallbackModel,
+      fallbackModel: identical(fallbackModel, _kUnset)
+          ? this.fallbackModel
+          : fallbackModel as String?,
       gender: gender ?? this.gender,
       activityLevel: activityLevel ?? this.activityLevel,
       homeMetricTypes: homeMetricTypes ?? this.homeMetricTypes,
@@ -62,6 +68,7 @@ class SettingsController extends _$SettingsController {
     required void Function(String key) onKeyLoaded,
     required void Function(String modelId) onCustomModelLoaded,
     required void Function(UserProfile profile) onProfileLoaded,
+    required void Function(String modelId) onCustomFallbackLoaded,
   }) async {
     final settings = ref.read(settingsServiceProvider);
 
@@ -82,7 +89,15 @@ class SettingsController extends _$SettingsController {
 
     final fallback = await settings.getFallbackModel();
     if (fallback != null) {
-      state = state.copyWith(fallbackModel: fallback);
+      final isKnownFallback = availableModels.any(
+        (m) => m.id == fallback && m.id != 'custom',
+      );
+      if (isKnownFallback) {
+        state = state.copyWith(fallbackModel: fallback);
+      } else {
+        state = state.copyWith(fallbackModel: 'custom');
+        onCustomFallbackLoaded(fallback);
+      }
     }
 
     final profile = await settings.getUserProfile();
@@ -123,6 +138,7 @@ class SettingsController extends _$SettingsController {
   Future<void> save({
     required String apiKey,
     required String customModel,
+    required String customFallbackModel,
     required String age,
     required String weight,
     required String height,
@@ -142,7 +158,10 @@ class SettingsController extends _$SettingsController {
         await settings.saveAIModel(modelToSave);
       }
 
-      await settings.saveFallbackModel(state.fallbackModel);
+      final fallbackToSave = state.fallbackModel == 'custom'
+          ? customFallbackModel.trim()
+          : state.fallbackModel;
+      await settings.saveFallbackModel(fallbackToSave);
 
       final parsedAge = int.tryParse(age.trim());
       final parsedWeight = _parseGoal(weight);

--- a/lib/features/settings/presentation/settings_page.dart
+++ b/lib/features/settings/presentation/settings_page.dart
@@ -296,6 +296,8 @@ class _SettingsSections extends StatelessWidget {
         AIConfigurationSection(
           apiKeyController: formManager.apiKeyController,
           customModelController: formManager.customModelController,
+          customFallbackModelController:
+              formManager.customFallbackModelController,
           selectedModel: state.selectedModel,
           fallbackModel: state.fallbackModel,
           availableModels: controller.availableModels,

--- a/lib/features/settings/presentation/widgets/ai_configuration_section.dart
+++ b/lib/features/settings/presentation/widgets/ai_configuration_section.dart
@@ -8,6 +8,7 @@ class AIConfigurationSection extends StatelessWidget {
     super.key,
     required this.apiKeyController,
     required this.customModelController,
+    required this.customFallbackModelController,
     required this.selectedModel,
     this.fallbackModel,
     required this.availableModels,
@@ -16,6 +17,7 @@ class AIConfigurationSection extends StatelessWidget {
   });
   final TextEditingController apiKeyController;
   final TextEditingController customModelController;
+  final TextEditingController customFallbackModelController;
   final String selectedModel;
   final String? fallbackModel;
   final List<AIModelInfo> availableModels;
@@ -222,6 +224,17 @@ class AIConfigurationSection extends StatelessWidget {
             includeNone: true,
             onChanged: onFallbackModelChanged,
           ),
+          if (fallbackModel == 'custom') ...[
+            const Gap(8),
+            TextField(
+              controller: customFallbackModelController,
+              decoration: const InputDecoration(
+                labelText: 'Custom Fallback Model ID (OpenRouter)',
+                border: OutlineInputBorder(),
+                hintText: 'e.g. meta-llama/llama-3-70b-instruct',
+              ),
+            ),
+          ],
         ],
       ],
     );


### PR DESCRIPTION
The fallback model could never be reset back to None once set, because SettingsState.copyWith used `fallbackModel ?? this.fallbackModel`, which treats an explicit null as "not provided". Introduce a sentinel default so null (None) is distinguishable from omission.

Also add support for an arbitrary custom fallback model (mirroring the primary model's custom option): selecting "Custom OpenRouter model" reveals a text field; the entered id is saved as-is, and an unknown stored fallback is mapped back to the custom field on load. Fallback changes are now tracked for unsaved-changes detection.