### PR TITLE
Show the actual OpenRouter error in a dialog when AI analysis fails

### DIFF
--- a/lib/core/services/ai_service.dart
+++ b/lib/core/services/ai_service.dart
@@ -3,6 +3,17 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:nutrinutri/core/domain/user_profile.dart';
 
+/// An error raised while talking to OpenRouter that carries a message suitable
+/// for showing directly to the user (either OpenRouter's own error text or a
+/// friendly "no internet connection" message).
+class AiRequestException implements Exception {
+  const AiRequestException(this.message);
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
 class AIService {
   AIService({required this.apiKey, required this.model});
   static const String _baseUrl =
@@ -124,6 +135,48 @@ Calculate calories based on the user profile provided and standard MET values.
         error.toString().contains('ClientException');
   }
 
+  /// Whether [error] looks like a connectivity failure rather than an API
+  /// error.  Avoids importing `dart:io` (which would break web builds) by
+  /// matching on type and message text.
+  bool _isNetworkError(Object error) {
+    if (error is http.ClientException) return true;
+    final text = error.toString();
+    return text.contains('SocketException') ||
+        text.contains('Failed host lookup') ||
+        text.contains('Connection refused') ||
+        text.contains('Network is unreachable') ||
+        text.contains('Connection closed') ||
+        text.contains('XMLHttpRequest') ||
+        text.contains('Failed to fetch');
+  }
+
+  /// Builds a user-facing message from a non-200 OpenRouter response, using
+  /// OpenRouter's own error text when it can be parsed out of the body.
+  String _describeApiError(int statusCode, String body) {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map) {
+        final error = decoded['error'];
+        if (error is Map && error['message'] is String) {
+          return 'OpenRouter error ($statusCode): ${error['message']}';
+        }
+        if (error is String && error.isNotEmpty) {
+          return 'OpenRouter error ($statusCode): $error';
+        }
+        if (decoded['message'] is String) {
+          return 'OpenRouter error ($statusCode): ${decoded['message']}';
+        }
+      }
+    } catch (_) {
+      // Body was not JSON; fall through to the raw text.
+    }
+
+    final trimmed = body.trim();
+    return trimmed.isEmpty
+        ? 'OpenRouter request failed (HTTP $statusCode).'
+        : 'OpenRouter error ($statusCode): $trimmed';
+  }
+
   Future<Map<String, dynamic>> _chatCompletion({
     required List<Map<String, dynamic>> messages,
     String? modelOverride,
@@ -153,7 +206,9 @@ Calculate calories based on the user profile provided and standard MET values.
       );
 
       if (response.statusCode != 200) {
-        throw Exception('AI Error: ${response.statusCode} - ${response.body}');
+        throw AiRequestException(
+          _describeApiError(response.statusCode, response.body),
+        );
       }
 
       final data = jsonDecode(response.body);
@@ -166,6 +221,12 @@ Calculate calories based on the user profile provided and standard MET values.
         throw Exception('Request cancelled');
       }
       debugPrint('AI Service Error: $e');
+      if (e is AiRequestException) rethrow;
+      if (_isNetworkError(e)) {
+        throw const AiRequestException(
+          'No internet connection. Please check your network and try again.',
+        );
+      }
       rethrow;
     } finally {
       if (requestId != null && _activeRequests[requestId] == client) {

--- a/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/dashboard_page.dart
@@ -20,12 +20,45 @@ class DashboardPage extends ConsumerStatefulWidget {
 
 class _DashboardPageState extends ConsumerState<DashboardPage> {
   late DateTime _selectedDate;
+  bool _errorDialogVisible = false;
 
   @override
   void initState() {
     super.initState();
     final now = DateTime.now();
     _selectedDate = DateTime(now.year, now.month, now.day);
+  }
+
+  void _showAnalysisErrorDialog(AnalysisFailure failure) {
+    if (!mounted || _errorDialogVisible) return;
+    _errorDialogVisible = true;
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        icon: const Icon(Icons.error_outline),
+        title: const Text('Analysis Failed'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                failure.title,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const Gap(12),
+              Text(failure.message),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    ).whenComplete(() => _errorDialogVisible = false);
   }
 
   void _updateDate(int days) {
@@ -76,6 +109,13 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
   @override
   Widget build(BuildContext context) {
     final isDesktop = PlatformHelper.isDesktopOrWeb;
+
+    ref.listen(analysisFailuresProvider, (previous, next) {
+      final failure = next.value;
+      if (failure != null) {
+        _showAnalysisErrorDialog(failure);
+      }
+    });
 
     return LayoutBuilder(
       builder: (context, constraints) {

--- a/lib/features/diary/application/diary_controller.dart
+++ b/lib/features/diary/application/diary_controller.dart
@@ -15,11 +15,36 @@ import 'package:uuid/uuid.dart';
 
 part 'diary_controller.g.dart';
 
+/// Describes a failed AI analysis in terms suitable for showing to the user.
+class AnalysisFailure {
+  const AnalysisFailure({required this.title, required this.message});
+
+  /// What was being analyzed (the user's prompt, or a generic label).
+  final String title;
+
+  /// The error text: OpenRouter's own message or a "no internet" message.
+  final String message;
+}
+
+/// Emits an [AnalysisFailure] whenever a background AI analysis ultimately
+/// fails, so the UI can surface the concrete error to the user.
+@riverpod
+Stream<AnalysisFailure> analysisFailures(Ref ref) {
+  return ref.watch(diaryControllerProvider.notifier).analysisErrors;
+}
+
 @Riverpod(keepAlive: true)
 class DiaryController extends _$DiaryController {
+  final StreamController<AnalysisFailure> _analysisErrorController =
+      StreamController<AnalysisFailure>.broadcast();
+
+  /// Broadcast stream of analysis failures (see [analysisFailuresProvider]).
+  Stream<AnalysisFailure> get analysisErrors =>
+      _analysisErrorController.stream;
+
   @override
   FutureOr<void> build() {
-    // No state needed initially
+    ref.onDispose(_analysisErrorController.close);
   }
 
   Future<void> addOptimisticEntry({
@@ -109,6 +134,8 @@ class DiaryController extends _$DiaryController {
     final userProfile = await settingsService.getUserProfile();
     final base64Image = await _imageToBase64(entry.imagePath);
 
+    Object? lastError;
+
     try {
       final result = await _analyzeEntry(
         aiService: aiService,
@@ -122,6 +149,7 @@ class DiaryController extends _$DiaryController {
       if (_isCancellationError(error)) {
         return;
       }
+      lastError = error;
     }
 
     if (fallbackModel != null && fallbackModel.isNotEmpty) {
@@ -139,10 +167,30 @@ class DiaryController extends _$DiaryController {
         if (_isCancellationError(error)) {
           return;
         }
+        lastError = error;
       }
     }
 
     await _updateFailed(entry);
+    _emitAnalysisError(entry, lastError);
+  }
+
+  void _emitAnalysisError(DiaryEntry entry, Object? error) {
+    if (_analysisErrorController.isClosed) return;
+
+    final message = error is AiRequestException
+        ? error.message
+        : 'Could not analyze this entry.\n\n${error ?? 'Unknown error'}';
+
+    final prompt = entry.description?.trim();
+    _analysisErrorController.add(
+      AnalysisFailure(
+        title: prompt != null && prompt.isNotEmpty
+            ? prompt
+            : _fallbackName(entry.type),
+        message: message,
+      ),
+    );
   }
 
   Future<void> _updateSuccess(

--- a/lib/features/diary/application/diary_controller.g.dart
+++ b/lib/features/diary/application/diary_controller.g.dart
@@ -8,6 +8,52 @@ part of 'diary_controller.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
+/// Emits an [AnalysisFailure] whenever a background AI analysis ultimately
+/// fails, so the UI can surface the concrete error to the user.
+
+@ProviderFor(analysisFailures)
+final analysisFailuresProvider = AnalysisFailuresProvider._();
+
+/// Emits an [AnalysisFailure] whenever a background AI analysis ultimately
+/// fails, so the UI can surface the concrete error to the user.
+
+final class AnalysisFailuresProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<AnalysisFailure>,
+          AnalysisFailure,
+          Stream<AnalysisFailure>
+        >
+    with $FutureModifier<AnalysisFailure>, $StreamProvider<AnalysisFailure> {
+  /// Emits an [AnalysisFailure] whenever a background AI analysis ultimately
+  /// fails, so the UI can surface the concrete error to the user.
+  AnalysisFailuresProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'analysisFailuresProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$analysisFailuresHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<AnalysisFailure> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<AnalysisFailure> create(Ref ref) {
+    return analysisFailures(ref);
+  }
+}
+
+String _$analysisFailuresHash() => r'e343b9a88dc158f745fab158284bcf67373d7318';
 
 @ProviderFor(DiaryController)
 final diaryControllerProvider = DiaryControllerProvider._();
@@ -33,7 +79,7 @@ final class DiaryControllerProvider
   DiaryController create() => DiaryController();
 }
 
-String _$diaryControllerHash() => r'2e69ccf7ea8aea6f11dc8d0d05a88e5dc31b53be';
+String _$diaryControllerHash() => r'5a3b3a0da00690d034d732d5aebc857e75d92cd9';
 
 abstract class _$DiaryController extends $AsyncNotifier<void> {
   FutureOr<void> build();


### PR DESCRIPTION
Show the actual OpenRouter error in a dialog when AI analysis fails                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                   
  Problem                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
  When an AI analysis request to OpenRouter failed, the entry silently became "Analysis Failed" and the underlying error was swallowed — the user had no idea why it failed (bad API key? rate limit? no internet?). The raw error was discarded in the analysis catch blocks.                                     
                                                                                                                                                                                                                                                                                                                   
  What this adds                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                   
  On failure, the app now surfaces the concrete reason in a dialog, without interrupting anything:                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                   
  - A non-dismissable-by-tap "Analysis Failed" AlertDialog with the prompt, the error message, and a Close button.                                                                                                                                                                                                 
  - The message is either OpenRouter's own error text (e.g. OpenRouter error (401): No auth credentials found) or a friendly "No internet connection…" message for connectivity failures.                                                                                                                          
  - The app keeps running; the entry is still marked failed (with its existing retry action) exactly as before.                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                   
  How it works                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                   
  - ai_service.dart — introduces a typed AiRequestException that carries a user-facing message. Non-200 responses parse OpenRouter's JSON error body (error.message) into a readable string; connectivity failures are detected by exception type/text (deliberately without importing dart:io, so web builds are  
  unaffected) and mapped to the "no internet" message.                                                                                                                                                                                                                                                             
  - diary_controller.dart — _analyzeAndFill now retains the last error after the primary and fallback attempts both fail, marks the entry failed as before, and emits an AnalysisFailure { title, message } on a broadcast stream. A new analysisFailuresProvider exposes that stream. (Background analysis is     
  fire-and-forget, so the error is delivered via a stream rather than a return value.)                                                                                                                                                                                                                             
  - dashboard_page.dart — ref.listen(analysisFailuresProvider, …) shows the dialog when a failure arrives, guarded by a flag so duplicate failures don't stack dialogs. The dashboard is the persistent home screen, so it reliably catches errors that surface after the add-entry sheet has closed.              
                                                                                                                                                                                                                                                                                                                   
  Scope / notes                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                   
  - Fires at the moment of failure. Viewing the error later by tapping a failed entry is intentionally out of scope (easy follow-up if wanted).                                                                                                                                                                    
  - Files: ai_service.dart, diary_controller.dart (+ generated .g.dart), dashboard_page.dart.                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                   
  Testing                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
  - flutter analyze clean; builds and runs on macOS.                                                                                                                                                                                                                                                               
  - Manual: invalid API key → dialog shows OpenRouter's 401 text; network disabled → dialog shows the "no internet" message; in both cases the app stays responsive and the entry keeps its retry option.                                                                                                          
                                                                                                                                                                                                                                                                                                                   
  ---                                                                                                                                                                                                                                                                                                              
  🤖 This PR was created with the help of AI. 