### PR TITLE
Log entries on the selected day, not today

### DIFF
--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -69,9 +69,19 @@ final routerProvider = Provider<GoRouter>((ref) {
           final initialType = typeStr == 'exercise'
               ? EntryType.exercise
               : EntryType.food;
+          final dateMillis = int.tryParse(
+            state.uri.queryParameters['date'] ?? '',
+          );
+          final initialDate = dateMillis != null
+              ? DateTime.fromMillisecondsSinceEpoch(dateMillis)
+              : null;
           return MaterialPage(
             key: state.pageKey,
-            child: AddEntryPage(existingEntry: entry, initialType: initialType),
+            child: AddEntryPage(
+              existingEntry: entry,
+              initialType: initialType,
+              initialDate: initialDate,
+            ),
           );
         },
       ),

--- a/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/dashboard_page.dart
@@ -40,11 +40,13 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
   }
 
   String _addEntryRoute({required bool isExercise}) {
-    if (!isExercise) return '/add-entry';
-
     return Uri(
       path: '/add-entry',
-      queryParameters: {'type': 'exercise'},
+      queryParameters: {
+        if (isExercise) 'type': 'exercise',
+        // Log onto the day currently selected on the dashboard, not today.
+        'date': _selectedDate.millisecondsSinceEpoch.toString(),
+      },
     ).toString();
   }
 

--- a/lib/features/logging/presentation/add_entry_controller.dart
+++ b/lib/features/logging/presentation/add_entry_controller.dart
@@ -61,12 +61,13 @@ class AddEntryController extends _$AddEntryController {
     );
   }
 
-  void initializeWithType(EntryType type) {
+  void initializeWithType(EntryType type, {DateTime? date}) {
     state = state.copyWith(
       type: type,
       selectedIcon: type == EntryType.exercise
           ? 'directions_run'
           : 'restaurant',
+      selectedDate: date,
     );
   }
 

--- a/lib/features/logging/presentation/add_entry_page.dart
+++ b/lib/features/logging/presentation/add_entry_page.dart
@@ -16,9 +16,14 @@ class AddEntryPage extends ConsumerStatefulWidget {
     super.key,
     this.existingEntry,
     this.initialType = EntryType.food,
+    this.initialDate,
   });
   final DiaryEntry? existingEntry;
   final EntryType initialType;
+
+  /// The day the new entry should be logged on (the day selected on the
+  /// dashboard). Defaults to today when null.
+  final DateTime? initialDate;
 
   @override
   ConsumerState<AddEntryPage> createState() => _AddEntryPageState();
@@ -42,9 +47,12 @@ class _AddEntryPageState extends ConsumerState<AddEntryPage> {
         _formManager.initializeWithEntry(widget.existingEntry!);
       });
     } else {
-      // Initialize with type
+      // Initialize with type (and the day selected on the dashboard)
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        _formManager.initializeWithType(widget.initialType);
+        _formManager.initializeWithType(
+          widget.initialType,
+          date: widget.initialDate,
+        );
       });
     }
   }

--- a/lib/features/logging/presentation/managers/add_entry_form_manager.dart
+++ b/lib/features/logging/presentation/managers/add_entry_form_manager.dart
@@ -59,8 +59,10 @@ class AddEntryFormManager {
     onStateChanged();
   }
 
-  void initializeWithType(EntryType type) {
-    ref.read(addEntryControllerProvider.notifier).initializeWithType(type);
+  void initializeWithType(EntryType type, {DateTime? date}) {
+    ref
+        .read(addEntryControllerProvider.notifier)
+        .initializeWithType(type, date: date);
     onStateChanged();
   }
 


### PR DESCRIPTION
Log entries on the selected day, not today                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                   
  Problem                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
  When you selected a past (or future) day on the dashboard's date switcher and tapped Log Food / Log Exercise, the new entry was still created on today. Nothing carried the day you were viewing into the add-entry flow, so the controller always defaulted its date to DateTime.now().                         
                                                                                                                                                                                                                                                                                                                   
  Fix                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                   
  Thread the dashboard's currently selected day through the add-entry flow:                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                   
  - dashboard_page.dart — _addEntryRoute now includes ?date=<millisSinceEpoch> for the selected day (for both food and exercise).                                                                                                                                                                                  
  - router.dart — parses the date query param into an initialDate.                                                                                                                                                                                                                                                 
  - add_entry_page.dart — new initialDate field, passed into initialization.                                                                                                                                                                                                                                       
  - add_entry_form_manager.dart / add_entry_controller.dart — initializeWithType(type, {date}) sets the controller's selectedDate to the passed day, falling back to today when absent.                                                                                                                            
                                                                                                                                                                                                                                                                                                                   
  Only the day follows the selection; time-of-day still defaults to the current clock time, and the date remains editable via the existing date picker on the add-entry screen.                                                                                                                                    
                                                                                                                                                                                                                                                                                                                   
  Testing                                                                                                                                                                                                                                                                                                          

  - flutter analyze clean; builds and runs on macOS.
  - Manual: selected a different day on the dashboard, logged an entry, and confirmed it appears on that day (and persists when switching dates back and forth).

Closes #6
                                                                                                                                                                                                                                                                                                                   
  ---                                                                                                                                                                                                                                                                                                              
  🤖 This PR was created with the help of AI.