### PR TITLE
Sync results (API key, profile) weren't reflected until app restart

### DIFF
--- a/lib/core/providers.dart
+++ b/lib/core/providers.dart
@@ -30,13 +30,23 @@ SettingsService settingsService(Ref ref) {
   );
 }
 
+/// Emits whenever a Drive sync pulls down changes that were applied
+/// locally, so keepAlive providers reading synced data (API key, profile,
+/// diary entries) know to refetch instead of serving a stale cached value.
+@riverpod
+Stream<void> syncUpdate(Ref ref) {
+  return ref.watch(syncServiceProvider).onSyncCompleted;
+}
+
 @Riverpod(keepAlive: true)
 Future<String?> apiKey(Ref ref) async {
+  ref.watch(syncUpdateProvider);
   return ref.watch(settingsServiceProvider).getApiKey();
 }
 
 @Riverpod(keepAlive: true)
 Future<UserProfile?> userProfile(Ref ref) async {
+  ref.watch(syncUpdateProvider);
   return ref.watch(settingsServiceProvider).getUserProfile();
 }
 

--- a/lib/core/providers.g.dart
+++ b/lib/core/providers.g.dart
@@ -134,6 +134,50 @@ final class SettingsServiceProvider
 
 String _$settingsServiceHash() => r'3a244e957496328dc9b67abf4413d6d6a2bb13fc';
 
+/// Emits whenever a Drive sync pulls down changes that were applied
+/// locally, so keepAlive providers reading synced data (API key, profile,
+/// diary entries) know to refetch instead of serving a stale cached value.
+
+@ProviderFor(syncUpdate)
+final syncUpdateProvider = SyncUpdateProvider._();
+
+/// Emits whenever a Drive sync pulls down changes that were applied
+/// locally, so keepAlive providers reading synced data (API key, profile,
+/// diary entries) know to refetch instead of serving a stale cached value.
+
+final class SyncUpdateProvider
+    extends $FunctionalProvider<AsyncValue<void>, void, Stream<void>>
+    with $FutureModifier<void>, $StreamProvider<void> {
+  /// Emits whenever a Drive sync pulls down changes that were applied
+  /// locally, so keepAlive providers reading synced data (API key, profile,
+  /// diary entries) know to refetch instead of serving a stale cached value.
+  SyncUpdateProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'syncUpdateProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$syncUpdateHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<void> $createElement($ProviderPointer pointer) =>
+      $StreamProviderElement(pointer);
+
+  @override
+  Stream<void> create(Ref ref) {
+    return syncUpdate(ref);
+  }
+}
+
+String _$syncUpdateHash() => r'10a4d54f9d17cc704a6e664d05cc1510e593301c';
+
 @ProviderFor(apiKey)
 final apiKeyProvider = ApiKeyProvider._();
 
@@ -165,7 +209,7 @@ final class ApiKeyProvider
   }
 }
 
-String _$apiKeyHash() => r'924832eaef3085a68ee2a4785acc71d4f23887b0';
+String _$apiKeyHash() => r'820b66d2e07b3f387fe97a276e86000ac1684663';
 
 @ProviderFor(userProfile)
 final userProfileProvider = UserProfileProvider._();
@@ -204,7 +248,7 @@ final class UserProfileProvider
   }
 }
 
-String _$userProfileHash() => r'72317a9f015e7d336011f2e22f1c7ccd45601ae3';
+String _$userProfileHash() => r'4917d99f66f7a2287d291b8aa29b07ccfb7cb536';
 
 @ProviderFor(aiService)
 final aiServiceProvider = AiServiceProvider._();

--- a/lib/features/dashboard/presentation/dashboard_providers.dart
+++ b/lib/features/dashboard/presentation/dashboard_providers.dart
@@ -13,11 +13,6 @@ class DailySummaryData {
 }
 
 @riverpod
-Stream<void> syncUpdate(Ref ref) {
-  return ref.watch(syncServiceProvider).onSyncCompleted;
-}
-
-@riverpod
 Future<Map<String, double>> dailySummary(Ref ref, DateTime date) async {
   ref.watch(syncUpdateProvider);
   final diaryService = ref.watch(diaryServiceProvider);

--- a/lib/features/dashboard/presentation/dashboard_providers.g.dart
+++ b/lib/features/dashboard/presentation/dashboard_providers.g.dart
@@ -9,39 +9,6 @@ part of 'dashboard_providers.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
-@ProviderFor(syncUpdate)
-final syncUpdateProvider = SyncUpdateProvider._();
-
-final class SyncUpdateProvider
-    extends $FunctionalProvider<AsyncValue<void>, void, Stream<void>>
-    with $FutureModifier<void>, $StreamProvider<void> {
-  SyncUpdateProvider._()
-    : super(
-        from: null,
-        argument: null,
-        retry: null,
-        name: r'syncUpdateProvider',
-        isAutoDispose: true,
-        dependencies: null,
-        $allTransitiveDependencies: null,
-      );
-
-  @override
-  String debugGetCreateSourceHash() => _$syncUpdateHash();
-
-  @$internal
-  @override
-  $StreamProviderElement<void> $createElement($ProviderPointer pointer) =>
-      $StreamProviderElement(pointer);
-
-  @override
-  Stream<void> create(Ref ref) {
-    return syncUpdate(ref);
-  }
-}
-
-String _$syncUpdateHash() => r'10a4d54f9d17cc704a6e664d05cc1510e593301c';
-
 @ProviderFor(dailySummary)
 final dailySummaryProvider = DailySummaryFamily._();
 

--- a/lib/features/settings/presentation/settings_page.dart
+++ b/lib/features/settings/presentation/settings_page.dart
@@ -72,6 +72,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   Future<void> _handleSync() async {
     try {
       final result = await ref.read(settingsControllerProvider.notifier).sync();
+      if (result.downloaded > 0) {
+        await _loadSettings();
+      }
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(


### PR DESCRIPTION
### Problem                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                   
  After a Google Drive sync pulled down changes from another device, the Settings screen didn't show them until the user left and re-entered Settings — and in the specific case of the OpenRouter API key, it never showed up at all, even after re-entering Settings or navigating around the app.               
                                                                                                                                                                                                                                                                                                                   
  **Root cause:** `apiKeyProvider` and `userProfileProvider` are `keepAlive` Riverpod `FutureProvider`s. Once read for the first time (e.g. right after a fresh install, before any sync has happened), their result is cached indefinitely — nothing was invalidating them when `SyncService` wrote new data into the local database.                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                   
  - `userProfileProvider` *looked* fine because `SettingsController.loadSettings()` happens to bypass the cache — it reads the profile straight from `SettingsService.getUserProfile()` instead of through the provider. That's why weight/height appeared to sync correctly.                                      
  - `apiKeyProvider` has no such bypass — `loadSettings()` reads it via `ref.read(apiKeyProvider.future)`. On a clean install this resolves to `null` before the first sync and then stays cached at `null` forever, since nothing ever calls `ref.invalidate(apiKeyProvider)` outside of the user manually saving settings. This is why the API key specifically never synced from one device to another, no matter how many times the user reopened Settings.                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                   
  ### Fix                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
  - Added a shared `syncUpdateProvider` in `core/providers.dart` (a `Stream<void>` wrapping `SyncService.onSyncCompleted`), and made `apiKeyProvider` / `userProfileProvider` watch it. Whenever a sync pulls down and applies remote changes, both providers are invalidated and refetch from the database instead of serving a stale cached value.                                                                                                                                                                                                                                                                                 
  - Removed the duplicate `syncUpdateProvider` that `dashboard_providers.dart` had defined locally for the same purpose; it now reuses the shared one from `core/providers.dart` (which it already imports).                                                                                                       
  - `SettingsPage._handleSync()` now calls `_loadSettings()` right after a sync that actually downloaded changes (`result.downloaded > 0`), so the form fields refresh immediately instead of requiring the user to leave and re-enter the screen.                                                                 
                                                                                                                                                                                                                                                                                                                   
  ### Testing                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                   
  - `flutter analyze` — no issues.                                                                                                                                                                                                                                                                                 
  - Regenerated Riverpod codegen (`dart run build_runner build --delete-conflicting-outputs`).                                                                                                                                                                                                                     
  - Manual: sign in on device A, save an API key + profile, sync; on a clean install of device B, sign in and hit "Sync now" — API key and profile now appear immediately without restarting the app.