### PR TITLE
Add canonical URL tag to landing page

### DIFF
--- a/landing/src/layouts/Layout.astro
+++ b/landing/src/layouts/Layout.astro
@@ -8,6 +8,8 @@ const {
     title,
     description = "NutriNutri - The Private, AI-Powered Nutrition Tracker",
 } = Astro.props;
+
+const canonicalURL = new URL(Astro.url.pathname, "http://nutrinutri.popelis.sk/");
 ---
 
 <!doctype html>
@@ -17,6 +19,7 @@ const {
         <meta name="description" content={description} />
         <meta name="viewport" content="width=device-width" />
         <link rel="icon" type="image/svg+xml" href="/nutrinutri.svg" />
+        <link rel="canonical" href={canonicalURL} />
         <meta name="generator" content={Astro.generator} />
         <title>{title}</title>
         <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Summary
- Adds a `<link rel="canonical">` tag to the landing page layout, so search engines treat `http://nutrinutri.popelis.sk/` (and each sub-page) as the authoritative URL.

## Test plan
- [x] `astro build` succeeds
- [x] Verified generated `dist/index.html` and `dist/privacy-policy/index.html` contain the correct canonical URL for each page