### PR TITLE
Add PR CI: analyze, test, Android + web builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze_test:
+    name: Analyze & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+      - run: flutter pub get
+      - run: flutter analyze
+      - run: flutter test
+
+  # A real Android build (unsigned/debug) catches toolchain drift — e.g. a
+  # Flutter stable bump raising the minimum Android Gradle Plugin version —
+  # that analyze/test never sees. No signing secrets needed for a debug build.
+  build_android:
+    name: Build Android (debug)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+      - run: flutter pub get
+      - run: flutter build apk --debug
+
+  build_web:
+    name: Build Web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+      - run: flutter pub get
+      - run: flutter build web --release --base-href "/nutrinutri/"

--- a/test/benchmark_ai.dart
+++ b/test/benchmark_ai.dart
@@ -1,3 +1,6 @@
+// Standalone AI benchmark harness (run manually); console output is the point.
+// ignore_for_file: avoid_print, sort_constructors_first
+
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';

--- a/test/screenshots/screenshots_test.dart
+++ b/test/screenshots/screenshots_test.dart
@@ -10,7 +10,6 @@ import 'dart:ui' as ui;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:nutrinutri/core/db/app_database.dart';
 import 'package:nutrinutri/core/providers.dart';


### PR DESCRIPTION
## What

Adds a `CI` workflow that runs on every pull request (and on pushes to `main`):

- **Analyze & Test** — `flutter analyze` + `flutter test`
- **Build Android (debug)** — an unsigned Android build; no signing secrets required
- **Build Web** — the release web build

## Why

Until now the only workflow ran on release tags, so build breakage was only discovered at release time. A real Android build in CI catches toolchain drift (e.g. a Flutter stable bump raising the minimum Android Gradle Plugin version) that `analyze`/`test` can't see, before it reaches a release.

Runs are cancelled when superseded by a newer push to the same ref.